### PR TITLE
Update Roadmap dates and remove e10s

### DIFF
--- a/_pages/es/roadmap.md
+++ b/_pages/es/roadmap.md
@@ -12,8 +12,9 @@ In this page we describe the past, current and future activities that we have on
 
 *Note that this roadmap is subject to change.*
 
-| Now (Q3 2016)  | Next (Q4 2016)   | Later (Beyond) |
+| Now (Q1 2017)  | Next (Q2 2017)   | Later (Beyond) |
 | --- | --- | --- |
-| [Dive Into Rust](/es/developer-engagement/rust-hack/) | [WebVR Camp](/es/developer-engagement/webvr-camp/) |     |
-| [Web Compatibility Sprint](/es/developer-engagement/webcompat-sprint/) | [e10s and Add-ons](/es/experiments/e10s-addons/) |     |
-| [Test Pilot Install](/es/experiments/test-pilot/) | Next-Gen Firefox Hacking with The Janitor |     |
+| [Dive Into Rust](/es/rust-hack/) | Next-Gen Firefox Hacking with The Janitor |     |
+| [Web Compatibility Sprint](/es/webcompat-sprint/) |     |     |
+| [Test Pilot Install](/es/test-pilot/) |     |     |
+| [WebVR Camp](/es/webvr-camp/) |     |     |

--- a/_pages/fr/roadmap.md
+++ b/_pages/fr/roadmap.md
@@ -12,8 +12,9 @@ In this page we describe the past, current and future activities that we have on
 
 *Note that this roadmap is subject to change.*
 
-| Now (Q3 2016)  | Next (Q4 2016)   | Later (Beyond) |
+| Now (Q1 2017)  | Next (Q2 2017)   | Later (Beyond) |
 | --- | --- | --- |
-| [Dive Into Rust](/fr/developer-engagement/rust-hack/) | [WebVR Camp](/fr/developer-engagement/webvr-camp/) |     |
-| [Web Compatibility Sprint](/fr/developer-engagement/webcompat-sprint/) | [e10s and Add-ons](/fr/experiments/e10s-addons/) |     |
-| [Test Pilot Install](/fr/experiments/test-pilot/) | Next-Gen Firefox Hacking with The Janitor |     |
+| [Dive Into Rust](/fr/rust-hack/) | Next-Gen Firefox Hacking with The Janitor |     |
+| [Web Compatibility Sprint](/fr/webcompat-sprint/) |     |     |
+| [Test Pilot Install](/fr/test-pilot/) |     |     |
+| [WebVR Camp](/fr/webvr-camp/) |     |     |

--- a/_pages/pt/roadmap.md
+++ b/_pages/pt/roadmap.md
@@ -12,8 +12,9 @@ Nesta página descrevemos as atividades passadas, atuais e futuras que temos nes
 
 *Note that this roadmap is subject to change.*
 
-| Now (Q3 2016)  | Next (Q4 2016)   | Later (Beyond) |
+| Now (Q1 2017)  | Next (Q2 2017)   | Later (Beyond) |
 | --- | --- | --- |
-| [Dive Into Rust](/pt/developer-engagement/rust-hack/) | [WebVR Camp](/developer-engagement/pt/webvr-camp/) |     |
-| [Web Compatibility Sprint](/pt/developer-engagement/webcompat-sprint/) | [e10s and Add-ons](/pt/experiments/e10s-addons/) |     |
-| [Test Pilot Install](/pt/experiments/test-pilot/) | Next-Gen Firefox Hacking with The Janitor |     |
+| [Dive Into Rust](/pt/rust-hack/) | Next-Gen Firefox Hacking with The Janitor |     |
+| [Web Compatibility Sprint](/pt/webcompat-sprint/) |     |     |
+| [Test Pilot Install](/pt/test-pilot/) |     |     |
+| [WebVR Camp](/pt/webvr-camp/) |     |     |

--- a/_pages/roadmap.md
+++ b/_pages/roadmap.md
@@ -12,8 +12,9 @@ In this page we describe the past, current and future activities that we have on
 
 *Note that this roadmap is subject to change.*
 
-| Now (Q3 2016)  | Next (Q4 2016)   | Later (Beyond) |
+| Now (Q1 2017)  | Next (Q2 2017)   | Later (Beyond) |
 | --- | --- | --- |
-| [Dive Into Rust](/developer-engagement/rust-hack/) | [WebVR Camp](/developer-engagement/webvr-camp/) |     |
-| [Web Compatibility Sprint](/developer-engagement/webcompat-sprint/) | [e10s and Add-ons](/experiments/e10s-addons/) |     |
-| [Test Pilot Install](/experiments/test-pilot/) | Next-Gen Firefox Hacking with The Janitor |     |
+| [Dive Into Rust](/rust-hack/) | Next-Gen Firefox Hacking with The Janitor |     |
+| [Web Compatibility Sprint](/webcompat-sprint/) |     |     |
+| [Test Pilot Install](/test-pilot/) |     |     |
+| [WebVR Camp](/webvr-camp/) |     |     |


### PR DESCRIPTION
* Correct the dates in the heading
* Moves current initiatives to the "Now" column
* Removes "e10s and Addons" since that one is retired