### PR TITLE
Remove tabzilla

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,10 +19,6 @@
       <a class="page-link" href="/{{ l.lang-url }}roadmap/">{{ l.roadmap }}</a>
     </div>
 
-    <div id="tabzilla" class="hidden-xs hidden-sm">
-      <a href="https://www.mozilla.org/" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
-    </div>
-
   </div>
 
 </header>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -701,41 +701,6 @@ div.facebook {
     }
 }
 
-#tabzilla {
-    position:relative;
-    float:right
-}
-#tabzilla a {
-    position:relative;
-    display:block;
-    width:147px;
-    height:37px;
-    text-indent:120%;
-    white-space:nowrap;
-    overflow:hidden;
-    background-image:url(https://www.mozilla.org/media/img/tabzilla/tabzilla-static.png);
-    background-repeat:no-repeat;
-    z-index:2
-}
-@media(-webkit-min-device-pixel-ratio:1.5),(min--moz-device-pixel-ratio:1.5),(-o-min-device-pixel-ratio:3/2),(min-resolution:1.5dppx) {
-    #tabzilla a {
-        background-image:url(https://www.mozilla.org/media/img/tabzilla/tabzilla-static-high-res.png);
-        -webkit-background-size:147px 37px;
-        background-size:147px 37px
-    }
-}
-#tabzilla:before {
-    position:absolute;
-    display:block;
-    left:28px;
-    top:0;
-    width:88px;
-    height:26px;
-    content:'';
-    background-color:transparent;
-    z-index:1
-}
-
 #leaderboard {
     display: inline-block;
 }


### PR DESCRIPTION
Since tabzilla is not really used nowadays and does not match with our new branding anymore, we should remove it.