### PR TITLE
Link newly added Tech Speaker activity on roadmap

### DIFF
--- a/_pages/roadmap.md
+++ b/_pages/roadmap.md
@@ -14,7 +14,7 @@ In this page we describe the past, current and future activities that we have on
 
 | Now (Q1 2017)  | Next (Q2 2017)   | Later (Beyond) |
 | --- | --- | --- |
-| [Dive Into Rust](/rust-hack/) | Host a Tech Speaker | Open Source Corpus |
+| [Dive Into Rust](/rust-hack/) | [Host a Tech Speaker](/techspeakers/) | Open Source Corpus |
 | [Web Compatibility Sprint](/webcompat-sprint/) | Firefox Nightly | MLN |
 | [WebVR Camp](/webvr-camp/) |  |  |
 | [Community Participation Guidelines Review](/community-participation-guideline/) |  |  |


### PR DESCRIPTION
New addition of the Tech Speker activity should also be reflected and accessible from the roadmap.