### PR TITLE
Update terminology - webextensions-id

### DIFF
--- a/_pages/id/webextensions.md
+++ b/_pages/id/webextensions.md
@@ -1,10 +1,10 @@
 ---
 layout: activity
-title:  "Build Your Own WebExtension Add-on for Firefox"
+title:  "Build Your Own Extension for Firefox"
 subtitle: "in 1-3 hours"
 image: "/assets/img/webextensions-post-header.png"
-permalink: /id/webextensions/
-lang: id
+permalink: /webextensions/
+lang: en
 ref: webextensions
 parent: activities
 ---
@@ -18,13 +18,13 @@ Add-ons provide a safe, simple, and powerful way to personalize your browsing ex
 
 __Impact:__
 
-* 125 developers are introduced to and building WebExtensions either online or at regional events.
+* 125 developers are introduced to and building browser either online or at regional events.
 * 50 add-ons tagged with mozactivate17 in addons.mozilla.org.
-* 50 social media posts (Twitter, Facebook, blogs, etc.) about WebExtensions add-ons referencing #MozActivate
+* 50 social media posts (Twitter, Facebook, blogs, etc.) about that reference extension development and #Mozactivate.
 
 __Strength:__
 
-* 25 Mozillians organize Build Your Own WebExtension workshops
+* 25 Mozillians organize Build Your Own Extension workshops
 
 ### Goals for Your Workshop
 
@@ -37,44 +37,40 @@ __Strength:__
 
 Your audience for this event should be __people who have written HTML and JavaScript code in the past__.
 
-People with more JavaScript experience are encouraged to help beginners get started. If you have experience developing WebExtensions, you may skip the “Build Your First WebExtension” exercise and focus the activities listed in Part III.
+People with more JavaScript experience are encouraged to help beginners get started. If you have experience developing browser extensions, you may skip the “Build Your First Extension” exercise and focus the activities listed in Part III.
 </div>
 
 <div class="col-md-9" markdown="1">
 
 {: .alert .alert-info .impactbox}
 <span class="glyphicon glyphicon-ok-circle" aria-hidden="true"></span>
-Add-ons provide a safe, simple, and powerful way to personalize your browsing experience. With WebExtensions APIs, it’s easier than ever to create extensions that can be easily ported to Firefox, Chrome, Edge, and Opera. Through this activity you’ll help connect new developers with an opportunity to create add-ons to solve real problems and make their lives and the web better.
-
 Firefox is an open-source web browser that cares about user control and privacy, and add-ons provide a safe, simple, and powerful way to personalize your browsing experience. From blocking ads to organizing tabs, add-ons help make Firefox your own.
 
-It’s very easy to create add-ons for Firefox with [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions). This Web-based technology framework offers a powerful way to create browser extensions that can be easily ported to Chrome, Opera, and Edge, and you only need to know HTML, JavaScript and CSS to build them.
+It’s very easy to create add-ons for Firefox using [WebExtensions APIs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions). This Web-based technology framework offers a powerful way to create browser extensions that can be easily ported to Chrome, Opera, and Edge, and you only need to know HTML, JavaScript and CSS to build them.
 
 Through this activity you’ll help connect new developers with an opportunity to create add-ons to solve real problems and make their lives and the web better.
 
 
 ## Planning Your Workshop
 
-Help contribute to the open web by running a WebExtensions workshop. This activity can also be run solo.
+Help contribute to the open web by running an extension development workshop. This activity can also be run solo.
 
-1. Put an event team together
-2. Choose a date and secure a venue
-3. Choose whether this will be self-facilitated or co-facilitated with someone who has experience developing WebExtensions
-4. Set up the event on the Reps Portal ([instructions](https://wiki.mozilla.org/ReMo/SOPs/Event_hosting)). Please make sure the initiative is set to "MozActivate" and the functional area indicates "Add-ons".
-5. Get the word out! Invite your community to the event. If this activity is run together with a Campus Club, they can customize a flyer with your event information for print or electronic distribution.
-6. 2 - 3 days before the event, ask participants to complete the Pre-Event section on their own.
+1. Read the [event guide](/eventguide) on how to set up an event page and how to organize an event.
+2. Choose whether this will be self-facilitated or co-facilitated with someone who has experience developing browser extensions
+3. Get the word out! Invite your community to the event. If this activity is run together with a Campus Club, they can customize a flyer with your event information for print or electronic distribution.
+4. 2 - 3 days before the event, ask participants to complete the Pre-Event section on their own.
 
 __Duration:__ For duration, we recommend 1 - 3 hours with 5+ attendees. However you may choose to run the workshop as a series over a shorter time but multiple days.
 
 Attendees should bring their own laptops to the workshop, or the workshop should be held in a computer lab.
 
-You can make a copy and customize the [Build Your Own WebExtension Add-on template presentation](https://docs.google.com/presentation/d/1n7FEBCxSJdbfui2qjJv8vptsuchLB8-KES3SULVMI6w/edit#slide=id.g1bf30aaa6e_0_45) for your workshop.
+You can make a copy and customize the [Build Your Own Extension Add-on template presentation](https://docs.google.com/presentation/d/1n7FEBCxSJdbfui2qjJv8vptsuchLB8-KES3SULVMI6w/edit#slide=id.g1bf30aaa6e_0_45) for your workshop.
 
 There are two options for facilitation:
 1. Self-facilitate without a mentor.
   * If questions arise or if help is needed during the event, feel free to join the IRC channels #extdev and #webextensions to ask the community for support.
 
-2. Ask a person with experience building WebExtensions to provide guidance to attendees.
+2. Ask a person with experience building browser extensions to provide guidance to attendees.
   * Need help finding an experienced mentor? Send an email to cneiman \[at\] mozilla \[dot\] com with the link to your Reps event page and anticipated number of attendees.
   * Depending on location and availability, Mozilla might be able to send a staff member or volunteer expert to co-facilitate.
 
@@ -90,32 +86,32 @@ __Pre-Event__
 __Part I__
 
 * Give a quick introduction to attendees about what we are doing and why it is important.
-  * “Welcome to the \[name of event\]! I am \[name\]. Today, we are going to customize our Firefox browsers by developing our own add-ons to solve real problems in our own lives. Add-ons are a great way to add extra features to your browser, like blocking time-wasting websites during study hours, or turning images into cat pictures. With WebExtensions APIs, it’s now easier to create add-ons that are compatible with Firefox, Chrome, and Opera. Add-ons help keep users to be in control of their online experience, so your support in building them and the community around them matter.”
+  * “Welcome to the \[name of event\]! I am \[name\]. Today, we are going to customize our Firefox browsers by developing our own extensionsto solve real problems in our own lives. Add-ons are a great way to add extra features to your browser, like blocking time-wasting websites during study hours, or turning images into cat pictures. With WebExtensions APIs, it’s now easier to create add-ons that are compatible with Firefox, Chrome, and Opera. Add-ons help keep users to be in control of their online experience, so your support in building them and the community around them matter.”
 * Ask attendees to tweet about their attendance. Here is a suggested message:
-  * I’m customizing @Firefox by building my own #WebExtensions! #MozActivate
+  * I’m creating my own browser extension using #WebExtensions! #MozActivate
 * Ask participants if they already use add-ons. If they do, ask them to share what add-ons they use and how they are used.
 
 __Part II__
 
-1. Now it’s your turn. Using the tutorial on the Mozilla Developer Network, [build your first WebExtension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Your_first_WebExtension).
-2. After creating your first WebExtension, move on to Step 5 or follow the tutorial to [build a more complex WebExtension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Your_second_WebExtension).
-3. Once everyone in the group has made a WebExtension, take a few minutes to debrief. While you debrief, you can learn more about the [anatomy of a WebExtension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension), explore [more WebExtension examples](https://github.com/mdn/webextensions-examples), continue to Part III, or conclude the event.
+1. Now it’s your turn. Using the tutorial on MDN [build your first extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Your_first_WebExtension).
+2. After creating your first extension, move on to Step 5 or follow the tutorial to [build a more complex extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Your_second_WebExtension).
+3. Once everyone in the group has made an extension, take a few minutes to debrief. While you debrief, you can learn more about the [anatomy of a extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension), explore [more examples of APIs in action](https://github.com/mdn/webextensions-examples), continue to Part III, or conclude the event.
 
 __Part III (Bonus!)__
 
-1. As a group, brainstorm ideas for the kind of add-on you want to build using WebExtensions. You can find samples of add-ons users have requested [here](https://discourse.mozilla-community.org/search?q=idea%20category%3A35).
-  * The list of currently supported [JavaScript APIs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API) and [WebExtensions examples](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples) can provide inspiration.
+1. As a group, brainstorm ideas for the kind of add-on you want to build using WebExtensions APIs. You can find samples of add-ons users have requested [here](https://discourse.mozilla-community.org/search?q=idea%20category%3A35).
+  * The list of currently supported [JavaScript APIs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API) and [examples](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples) can provide inspiration.
   * Ask Chrome users to check if their favorite extensions are available in Firefox. If the extensions aren’t available, participants can try to build one for Firefox.
-  * Build a WebExtension that solves any of your real-world problems, or that customizes the browser in a way that benefits you personally.
-2. [Publish your WebExtension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Publishing_your_WebExtension) to addons.mozilla.org.
+  * Build an extension that solves any of your real-world problems, or that customizes the browser in a way that benefits you personally.
+2. [Publish your extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Publishing_your_WebExtension) to addons.mozilla.org.
 	* Once you have submitted your add-on, hover on Tools, then select "Manage My Submissions."
 	* From the actions menu, select "Edit Information."
 	* Then click the "Edit" button on the Basic Information section.
 	* Add the tag `mozactivate17` to your submission.
 	* Click the "Save Changes" button.
-3. Once your add-on has been approved (which might take a while), tweet a link to your published WebExtension! Here is a suggested message:
+3. Once your add-on has been approved (which might take a while), tweet a link to your published extension! Here is a suggested message:
   * I made an add-on using @MozWebExt for @mozamo! Check it out here: <link to add-on> #MozActivate
-4. Encourage attendees to continue the conversation by following @MozWebExt on Twitter, joining the mailing list dev-addons@mozilla.org, joining the IRC channels #addons and #extdev, joining the Telegram groups [@addons](https://telegram.me/addons) and [@addonschat](https://t.me/addonschat), and joining the [Add-ons Discourse Forum](https://discourse.mozilla-community.org/c/add-ons).
+4. Encourage attendees to continue the conversation by following @MozWebExt on Twitter, joining the mailing list dev-addons@mozilla.org, joining the IRC channels #addons and #extdev, joining the Telegram groups [@addons](https://telegram.me/addons) and [@addonschat](https://t.me/addonschat), and joining the [Add-ons Discourse Forum](https://discourse.mozilla.org/c/add-ons).
 
 ## Directly at the end of the activity
 Immediately after the event don’t forget to share the link to the impact form with your attendees:
@@ -141,7 +137,7 @@ You can get a copy [here](https://docs.google.com/presentation/d/1n7FEBCxSJdbfui
 
 __Want to join the Mozilla add-on developer community?__
 
-If you enjoyed creating your own add-on, the [dev-addons@mozilla.org mailing list](https://mail.mozilla.org/listinfo/dev-addons), IRC channels #addons, #webextensions and #extdev, Telegram group [@addons](https://telegram.me/addons), and [Add-ons Discourse Forum](https://discourse.mozilla-community.org/c/add-ons) are full of people just like you! Join these channels to ask questions, brainstorm ideas, and stay informed.
+If you enjoyed creating your own add-on, the [dev-addons@mozilla.org mailing list](https://mail.mozilla.org/listinfo/dev-addons), IRC channels #addons, #webextensions and #extdev, Telegram group [@addonschat](https://telegram.me/addonschat), and [Add-ons Discourse Forum](https://discourse.mozilla.org/c/add-ons) are full of people just like you! Join these channels to ask questions, brainstorm ideas, and stay informed.
 
 Also, keep your eyes on the [Add-ons Blog](https://blog.mozilla.org/addons/) to learn more about what’s going on in the world of add-ons.
 
@@ -155,7 +151,7 @@ Thanks again! We look forward to seeing you next time.
 
 * Fill out the post-event metrics on the event page you set up on the Reps portal.
 * Tell us about your event. This can be before or after. We love to hear about upcoming plans, and of course love to hear about what was achieved at the event with a picture or two!
-  * The Discourse thread can be found [here](https://discourse.mozilla-community.org/t/activate-build-your-own-webextension-add-on-for-firefox/13866)
+  * The Discourse thread can be found [here](https://discourse.mozilla.org/t/activate-build-your-own-webextension-add-on-for-firefox/13866)
 
 ## Tutorials & Other Resources
 
@@ -169,6 +165,7 @@ __Tutorials__
 
 __Other Resources__
 
-* [Example WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples)
+* [Example Extensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples)
+* [More documentation and resources on the Add-os Wiki](https://wiki.mozilla.org/Add-ons/developer/communication#Documentation_.26_Tutorials)
 * [Open Innovation Toolkit](https://toolkit.mozilla.org/)
 </div>

--- a/_pages/id/webextensions.md
+++ b/_pages/id/webextensions.md
@@ -4,7 +4,7 @@ title:  "Build Your Own Extension for Firefox"
 subtitle: "in 1-3 hours"
 image: "/assets/img/webextensions-post-header.png"
 permalink: /webextensions/
-lang: en
+lang: id
 ref: webextensions
 parent: activities
 ---
@@ -18,9 +18,9 @@ Add-ons provide a safe, simple, and powerful way to personalize your browsing ex
 
 __Impact:__
 
-* 125 developers are introduced to and building browser either online or at regional events.
+* 125 developers are introduced to and building browser extensions either online or at regional events.
 * 50 add-ons tagged with mozactivate17 in addons.mozilla.org.
-* 50 social media posts (Twitter, Facebook, blogs, etc.) about that reference extension development and #Mozactivate.
+* 50 social media posts (Twitter, Facebook, blogs, etc.) that reference extension development and #MozActivate.
 
 __Strength:__
 
@@ -95,7 +95,7 @@ __Part II__
 
 1. Now it’s your turn. Using the tutorial on MDN [build your first extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Your_first_WebExtension).
 2. After creating your first extension, move on to Step 5 or follow the tutorial to [build a more complex extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Your_second_WebExtension).
-3. Once everyone in the group has made an extension, take a few minutes to debrief. While you debrief, you can learn more about the [anatomy of a extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension), explore [more examples of APIs in action](https://github.com/mdn/webextensions-examples), continue to Part III, or conclude the event.
+3. Once everyone in the group has made an extension, take a few minutes to debrief. While you debrief, you can learn more about the [anatomy of an extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension), explore [more examples of APIs in action](https://github.com/mdn/webextensions-examples), continue to Part III, or conclude the event.
 
 __Part III (Bonus!)__
 


### PR DESCRIPTION
Updating extensions terminology based on guidance from https://wiki.mozilla.org/Add-ons/Terminology.