### PR TITLE
Change Rust Hack & Learn

### DIFF
--- a/_pages/id/rust-hack.md
+++ b/_pages/id/rust-hack.md
@@ -15,30 +15,31 @@ redirect_from: "/id/developer-engagement/rust-hack/"
 
 The Rust programming language will be important to the future of the web, making it safe and great. Having more developers understand, use and evangelize this language will advance make the web better and more secure.
 
-Rust will also be used extensively for Mozilla projects -- including this year as Servo (written in Rust) is advanced even further, and parts of it are moved into Gecko/Firefox. Having more Mozilla contributors know Rust will give them a chance to contribute to the most exciting and important technical projects coming up for Mozilla.
+Rust is used extensively for Mozilla projects -- including this year as Servo (written in Rust) is advanced even further, and parts of it are moved into Gecko/Firefox. Having more Mozilla contributors know Rust will give them a chance to contribute to the most exciting and important technical projects coming up for Mozilla.
+
+Rust is also a good project to be engaged in for people that don't want or can't participate in a Mozilla project, but like to be involved with something close.
 
 ### Goals for this area
 
 __Impact:__
 
 * 1,000 programmers/developers are introduced to and are well on their way to learning Rust
-* 10 blog posts about events or other local Rust activities
+* 10 ongoing Rust Hack and Learn events
 
 __Strength:__
 
 * 50 Mozillians organize Rust Hack and Learn events
-* 50 new people signed up to [Rust developer list](https://users.rust-lang.org)
 
 ## Audience for this activity
 
-Your audience for this event should be **programmers and developers**. Focus on people who are technical and already know languages like C or Python or other similar languages.
+Your audience for this event should be **programmers and developers**. Focus on people who are technical and already know languages like C or Python or other similar languages. Some outreach to beginners can be done.
 </div>
 
 <div class="col-md-9" markdown="1">
 
 {: .alert .alert-info .impactbox}
 <span class="glyphicon glyphicon-ok-circle" aria-hidden="true"></span>
-Having more developers understand, use and evangelize this language will advance make the web better and more secure.
+Having more developers understand, use and evangelize this language will advance make the web better and more secure. Rust is also a great way to learn about WebAssembly.
 
 Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety. [Find out more...](https://www.rust-lang.org)
 
@@ -51,41 +52,26 @@ Rust is a systems programming language that runs blazingly fast, prevents segfau
 
 Get your community behind this exciting new programming language by running a learning event.
 
-1. Put an event team together
-2. Choose a date and secure a venue
-3. Choose whether this will be self-facilitated or with someone who has Rust experience (see below)
+1. Put an event team together. Going alone is fine, but at least two people is advisable. Get in touch with the [Rust Community Team](mailto:community@rust-lang.org) and check the [Rust Community Calendar](https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com) - maybe there's already people in your area.
+2. Try to find people with Rust experience who want to help. If you find none, this is fine - many Hack and Learns started out by curious people.
+3. Choose a date and secure a venue. Ask the [Rust Community Team](mailto:community@rust-lang.org) for access to the calendar so that you can enter it there.  It will then be sent around with Rusts weekly newsletter and promoted in other fashions.
 4. Setup the event on Reps Portal ([instructions](https://wiki.mozilla.org/ReMo/SOPs/Event_hosting)). Please make sure the initiative is set to "MozActivate" and the functional area indicates "Rust".
+5. Get [Material](https://github.com/rust-community/resources) and print them to hand them out. You can also ask the [Rust Community Team](mailto:community@rust-lang.org) if they can send some stickers.
 
-For duration, we recommend a half-day (or full evening) event with a minimum of 15-25 attendees.
+For duration, we recommend at least 2-3 hours event with a minimum of 10 attendees.
 
-There are two options for facilitation:
-
-1. Ask a person with experience with Rust to attend and provide guidance to attendees. There are a few ways to try to find local Rust experts to invite:
-    * Reach out to the [Community Team](https://www.rust-lang.org/en-US/team.html#Community-team) - community-team [at] rust-lang [dot] org - they know the most active people in most regions.
-    * Via the [user groups](https://www.rust-lang.org/en-US/user-groups.html)
-    * At [rustaceans.org](http://www.rustaceans.org/)
-2. If the facilitators have little or no Rust experience, turn it into a learning session for everyone, where you go through the steps together. Some Mozillians have already done such sessions. For example our [Community Spaces](https://wiki.mozilla.org/Participation/Community_Spaces) have, so you can reach out the them to ask for some guidance.
+Some Mozillians have already done such sessions. For example our [Community Spaces](https://wiki.mozilla.org/Participation/Community_Spaces) have, so you can reach out the them to ask for some guidance.
 
 ## Event Flow
 
 * Install Rust
     * [rustup](https://www.rustup.rs) - recommended
     * [Rust downloads](https://www.rust-lang.org/en-US/other-installers.html) (alternative)
-* Read the [Rust book](https://doc.rust-lang.org/stable/book/)
-* Complete the [Rustlings](https://github.com/carols10cents/rustlings) (a great beginners course!)
-* Some projects with great first bugs:
-    * The Rust language and compiler
-        * [Labeled easy](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy)
-        * [Labeled mentor](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-mentor)
-    * [clippy - the popular Rust static analysis tool](https://github.com/Manishearth/rust-clippy)
-    * [Cargo - Rust’s package manager](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy)
-    * [rustfmt - the Rust source code formatting tool](https://github.com/rust-lang-nursery/rustfmt/issues)
-        * Though some are without clear instructions, the domain is easy to understand (it's mostly manipulating strings), and potentially engaging.
-    * [rustup - the Rust installer](https://github.com/rust-lang-nursery/rustup.rs/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
-    * Rust documentation
-        * [Labeled easy](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs+label%3AE-easy)
-        * [Standard library API docs](https://github.com/rust-lang/rust/issues/29329)
-    * [This Week in Rust](https://this-week-in-rust.org/) also publishes a call for participation each week with hot contribution ideas.
+- Get started!
+    * Read the [Rust book](https://doc.rust-lang.org/stable/book/)
+    * Check [Rust by Example](https://rustbyexample.com/)
+    * Complete some [Rustlings](https://github.com/carols10cents/rustlings) (a great beginners course!)
+    * Try to form some groups to find things they'd like to program.
 
 ## Directly at the end of the activity
 Immediately after the event don’t forget to share the link to the impact form with your attendees:
@@ -111,7 +97,7 @@ Additional to the recommended event flow here are some things we’d like you, t
     * [Here is the Discourse post to write to](https://discourse.mozilla-community.org/t/activate-mozilla-dive-into-rust/10073/1)
 
 ## Extra
-While the focus of this activity should be on these events, there are other ways to stay more involved with the Rust community after.
+While the focus of this activity should be on these events, people can get more involved more involved with the Rust community after.
 
 * Follow up with attendees to highlight [more things happening in the community to get involved with](https://www.rust-lang.org/en-US/community.html)
 </div>

--- a/_pages/id/rust-hack.md
+++ b/_pages/id/rust-hack.md
@@ -52,9 +52,9 @@ Rust is a systems programming language that runs blazingly fast, prevents segfau
 
 Get your community behind this exciting new programming language by running a learning event.
 
-1. Put an event team together. Going alone is fine, but at least two people is advisable. Get in touch with the [Rust Community Team](mailto:community@rust-lang.org) and check the [Rust Community Calendar](https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com) - maybe there's already people in your area.
+1. Put an event team together. Going alone is fine, but at least two people is advisable. Get in touch with the [[Rust Community Team](mailto:community@rust-lang.org)] and check the [Rust Community Calendar](https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com) - maybe there's already people in your area.
 2. Try to find people with Rust experience who want to help. If you find none, this is fine - many Hack and Learns started out by curious people.
-3. Choose a date and secure a venue. Ask the [Rust Community Team](mailto:community@rust-lang.org) for access to the calendar so that you can enter it there.  It will then be sent around with Rusts weekly newsletter and promoted in other fashions.
+3. Choose a date and secure a venue. Fill the [event template](https://github.com/rust-community/events-team/issues/new?template=new_meetup.md&labels=meetup) for access to the calendar so that you can enter it there.  It will then be sent around with Rusts weekly newsletter and promoted in other fashions.
 4. Setup the event on Reps Portal ([instructions](https://wiki.mozilla.org/ReMo/SOPs/Event_hosting)). Please make sure the initiative is set to "MozActivate" and the functional area indicates "Rust".
 5. Get [Material](https://github.com/rust-community/resources) and print them to hand them out. You can also ask the [Rust Community Team](mailto:community@rust-lang.org) if they can send some stickers.
 

--- a/_pages/rust-hack.md
+++ b/_pages/rust-hack.md
@@ -60,14 +60,13 @@ For duration, we recommend at least 2-3 hours event with a minimum of 10 attende
 1. Put an event team together. Going alone is fine, but at least two people is advisable. Check the [Rust Community Calendar](https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com) - maybe there's already people in your area. You can also get in touch with  the [Rust Community Team](mailto:community@rust-lang.org) for additional support.
 2. Try to find people with Rust experience who want to help. If you find none, this is fine - many Hack and Learns started out by curious people.
 
-
 Some Mozillians have already done such sessions. For example see [past Mozilla Reps events](https://reps.mozilla.org/events/#/period/past/category/rust/).
 
 **2-4 Weeks Before the Event**
 
 1. Read the [event guide](/eventguide/) on how to set up an event page and how to organize an event.
 1. Choose a date and secure a venue.
-1. Fill the [event template](https://github.com/rust-community/events-team/issues/new?template=new_meetup.md&labels=meetup,mozilla-activities) for access to the calendar so that you can enter it there.  It will then be sent around with Rust's weekly newsletter and promoted in other fashions. You can also ask the [Rust Swag Distributors](mailto:community-swag@rust-lang.org) if they can send some stickers.
+1. Fill the [event template](https://github.com/rust-community/events-team/issues/new?template=new_meetup.md&labels=meetup,mozilla-activities) for access to the calendar so that you can enter it there.  It will then be sent around with Rust's weekly newsletter and promoted in other fashions. You can also ask the [Rust Community Team](mailto:community@rust-lang.org?subject=[SWAG]) if they can send some stickers.
 1. Setup the event on the Reps Portal ([instructions](https://wiki.mozilla.org/ReMo/SOPs/Event_hosting)). Please make sure the initiative is set to "MozActivate" and the functional area indicates "Rust".
 
 **1 Week Before the Event**

--- a/_pages/rust-hack.md
+++ b/_pages/rust-hack.md
@@ -64,14 +64,21 @@ Some Mozillians have already done such sessions. For example our [Community Spac
 
 ## Event Flow
 
-* Install Rust
-    * [rustup](https://www.rustup.rs) - recommended
-    * [Rust downloads](https://www.rust-lang.org/en-US/other-installers.html) (alternative)
-- Get started!
-    * Read the [Rust book](https://doc.rust-lang.org/stable/book/)
-    * Check [Rust by Example](https://rustbyexample.com/)
-    * Complete some [Rustlings](https://github.com/carols10cents/rustlings) (a great beginners course!)
-    * Try to form some groups to find things they'd like to program.
+Hack & Learn are mainly structureless, which allows for people of all experience levels to feel great. They can follow their interests and can interact with people. As an organiser, you can try to also bring your own project, please note that you will the first point of contact for problems.
+
+* Give people some time to get in and wait 5-10 minutes to get them set up and comfortable
+* Do an intro round (5 minutes). Ask everyone for:
+  - Who they are
+  - What previous programming experiences they have
+  - What they intend to work on (or if they are searching for a project)
+* Encourage people to group up or work alone
+* Introduce new people to the existing resources
+* Help people that don't have a project to find one
+* Open time: people should just work on whatever they have. Some people will just chat, make sure they don't disturb others.
+* Closing: go through the group again and ask people for their progress.
+  - If time allows, make a [Show \& Tell](https://en.wikipedia.org/wiki/Show_and_tell_(education)) and have people actually present their learnings in a very short talk.
+
+If the event is just 2 hours long, keep the intro and the closing short. If you spend 2.5 hours or more, you can spend more time on the closing. If the event is even longer, consider running something by the middle of it, to give people a moment to step away from the project.
 
 ## Directly at the end of the activity
 Immediately after the event don’t forget to share the link to the impact form with your attendees:

--- a/_pages/rust-hack.md
+++ b/_pages/rust-hack.md
@@ -67,7 +67,7 @@ Some Mozillians have already done such sessions. For example see [past Mozilla R
 
 1. Read the [event guide](/eventguide/) on how to set up an event page and how to organize an event.
 1. Choose a date and secure a venue.
-1. Fill the [event template](https://github.com/rust-community/events-team/issues/new?template=new_meetup.md&labels=meetup) for access to the calendar so that you can enter it there.  It will then be sent around with Rust's weekly newsletter and promoted in other fashions. You can also ask the [Rust Community Team](mailto:community@rust-lang.org) if they can send some stickers.
+1. Fill the [event template](https://github.com/rust-community/events-team/issues/new?template=new_meetup.md&labels=meetup,mozilla-activities) for access to the calendar so that you can enter it there.  It will then be sent around with Rust's weekly newsletter and promoted in other fashions. You can also ask the [Rust Swag Distributors](mailto:community-swag@rust-lang.org) if they can send some stickers.
 1. Setup the event on the Reps Portal ([instructions](https://wiki.mozilla.org/ReMo/SOPs/Event_hosting)). Please make sure the initiative is set to "MozActivate" and the functional area indicates "Rust".
 
 **1 Week Before the Event**
@@ -90,6 +90,7 @@ Hack & Learn are mainly structureless, which allows for people of all experience
 * Open time: people should just work on whatever they have. Some people will just chat, make sure they don't disturb others.
 * Closing: go through the group again and ask people for their progress.
   - If time allows, make a [Show \& Tell](https://en.wikipedia.org/wiki/Show_and_tell_(education)) and have people actually present their learnings in a very short talk.
+* If this is the first time you run it: ask people about their schedules and try to find a regular date for repeats.
 
 If the event is just 2 hours long, keep the intro and the closing short. If you spend 2.5 hours or more, you can spend more time on the closing. If the event is even longer, consider running something by the middle of it, to give people a moment to step away from the project.
 

--- a/_pages/rust-hack.md
+++ b/_pages/rust-hack.md
@@ -17,7 +17,7 @@ The Rust programming language will be important to the future of the web, making
 
 Rust is used extensively for Mozilla projects -- including this year as Servo (written in Rust) is advanced even further, and parts of it are moved into Gecko/Firefox. Having more Mozilla contributors know Rust will give them a chance to contribute to the most exciting and important technical projects coming up for Mozilla.
 
-Rust is also a good project to be engaged in for people that don't want or can't participate in a Mozilla project, but like to be involved with something close.
+Rust is also a good subject to get people closer to Mozilla gradually, as it has smaller project sizes and potential for individual contribution - for example by writing a useful library.
 
 ### Goals for this area
 
@@ -55,9 +55,9 @@ Rust is a systems programming language that runs blazingly fast, prevents segfau
 
 ## Activity Format
 
-For duration, we recommend at least 2-3 hours event with a minimum of 10 attendees.
+For duration, we recommend at least a 2-3 hours event with a minimum of 10 attendees.
 
-1. Put an event team together. Going alone is fine, but at least two people is advisable. Check the [Rust Community Calendar](https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com) - maybe there's already people in your area. You can also get in touch with  the [Rust Community Team](mailto:community@rust-lang.org) for additional support.
+1. Put an event team together. Going alone is fine, but at least two people is advisable. Check the [Rust Community Calendar](https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com) - maybe there's already people in your area. You can also get in touch with the [Rust Community Team](mailto:community@rust-lang.org) for additional support.
 2. Try to find people with Rust experience who want to help. If you find none, this is fine - many Hack and Learns started out by curious people.
 
 Some Mozillians have already done such sessions. For example see [past Mozilla Reps events](https://reps.mozilla.org/events/#/period/past/category/rust/).
@@ -139,7 +139,7 @@ In addition to the recommended event flow here are some things we’d like you, 
 [@rustlang]: https://twitter.com/rustlang
 
 ## Extra
-While the focus of this activity should be on these events, people can get more involved more involved with the Rust community after.
+While the focus of this activity should be on these events, people can get more involved with the Rust community after.
 
 * Follow up with attendees to highlight [more things happening in the community to get involved with](https://www.rust-lang.org/en-US/community.html)
 </div>

--- a/_pages/rust-hack.md
+++ b/_pages/rust-hack.md
@@ -88,7 +88,7 @@ Hack & Learn are mainly structureless, which allows for people of all experience
 * Help people that don't have a project to find one
 * Open time: people should just work on whatever they have. Some people will just chat, make sure they don't disturb others.
 * Closing: go through the group again and ask people for their progress.
-  - If time allows, make a [Show \& Tell](https://en.wikipedia.org/wiki/Show_and_tell_(education)) and have people actually present their learnings in a very short talk.
+  - If time allows, make a [Show & Tell](https://en.wikipedia.org/wiki/Show_and_tell_(education)) and have people actually present their learnings in a very short talk.
 * If this is the first time you run it: ask people about their schedules and try to find a regular date for repeats.
 
 If the event is just 2 hours long, keep the intro and the closing short. If you spend 2.5 hours or more, you can spend more time on the closing. If the event is even longer, consider running something by the middle of it, to give people a moment to step away from the project.

--- a/_pages/rust-hack.md
+++ b/_pages/rust-hack.md
@@ -15,30 +15,31 @@ redirect_from: "/developer-engagement/rust-hack/"
 
 The Rust programming language will be important to the future of the web, making it safe and great. Having more developers understand, use and evangelize this language will advance make the web better and more secure.
 
-Rust will also be used extensively for Mozilla projects -- including this year as Servo (written in Rust) is advanced even further, and parts of it are moved into Gecko/Firefox. Having more Mozilla contributors know Rust will give them a chance to contribute to the most exciting and important technical projects coming up for Mozilla.
+Rust is used extensively for Mozilla projects -- including this year as Servo (written in Rust) is advanced even further, and parts of it are moved into Gecko/Firefox. Having more Mozilla contributors know Rust will give them a chance to contribute to the most exciting and important technical projects coming up for Mozilla.
+
+Rust is also a good project to be engaged in for people that don't want or can't participate in a Mozilla project, but like to be involved with something close.
 
 ### Goals for this area
 
 __Impact:__
 
 * 1,000 programmers/developers are introduced to and are well on their way to learning Rust
-* 10 blog posts about events or other local Rust activities
+* 10 ongoing Rust Hack and Learn events
 
 __Strength:__
 
 * 50 Mozillians organize Rust Hack and Learn events
-* 50 new people signed up to [Rust developer list](https://users.rust-lang.org)
 
 ## Audience for this activity
 
-Your audience for this event should be **programmers and developers**. Focus on people who are technical and already know languages like C or Python or other similar languages.
+Your audience for this event should be **programmers and developers**. Focus on people who are technical and already know languages like C or Python or other similar languages. Some outreach to beginners can be done.
 </div>
 
 <div class="col-md-9" markdown="1">
 
 {: .alert .alert-info .impactbox}
 <span class="glyphicon glyphicon-ok-circle" aria-hidden="true"></span>
-Having more developers understand, use and evangelize this language will advance make the web better and more secure.
+Having more developers understand, use and evangelize this language will advance make the web better and more secure. Rust is also a great way to learn about WebAssembly.
 
 Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety. [Find out more...](https://www.rust-lang.org)
 
@@ -51,39 +52,26 @@ Rust is a systems programming language that runs blazingly fast, prevents segfau
 
 Get your community behind this exciting new programming language by running a learning event.
 
-1. Read the [event guide](/eventguide/) on how to set up an event page and how to organize an event.
-2. Choose whether this will be self-facilitated or with someone who has Rust experience (see below)
+1. Put an event team together. Going alone is fine, but at least two people is advisable. Get in touch with the [[Rust Community Team](mailto:community@rust-lang.org)] and check the [Rust Community Calendar](https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com) - maybe there's already people in your area.
+2. Try to find people with Rust experience who want to help. If you find none, this is fine - many Hack and Learns started out by curious people.
+3. Choose a date and secure a venue. Fill the [event template](https://github.com/rust-community/events-team/issues/new?template=new_meetup.md&labels=meetup) for access to the calendar so that you can enter it there.  It will then be sent around with Rusts weekly newsletter and promoted in other fashions.
+4. Setup the event on Reps Portal ([instructions](https://wiki.mozilla.org/ReMo/SOPs/Event_hosting)). Please make sure the initiative is set to "MozActivate" and the functional area indicates "Rust".
+5. Get [Material](https://github.com/rust-community/resources) and print them to hand them out. You can also ask the [Rust Community Team](mailto:community@rust-lang.org) if they can send some stickers.
 
-For duration, we recommend a half-day (or full evening) event with a minimum of 15-25 attendees.
+For duration, we recommend at least 2-3 hours event with a minimum of 10 attendees.
 
-There are two options for facilitation:
-
-1. Ask a person with experience with Rust to attend and provide guidance to attendees. There are a few ways to try to find local Rust experts to invite:
-    * Reach out to the [Community Team](https://www.rust-lang.org/en-US/team.html#Community-team) - community-team [at] rust-lang [dot] org - they know the most active people in most regions.
-    * Via the [user groups](https://www.rust-lang.org/en-US/user-groups.html)
-    * At [rustaceans.org](http://www.rustaceans.org/)
-2. If the facilitators have little or no Rust experience, turn it into a learning session for everyone, where you go through the steps together. Some Mozillians have already done such sessions. For example our [Community Spaces](https://wiki.mozilla.org/Participation/Community_Spaces) have, so you can reach out the them to ask for some guidance.
+Some Mozillians have already done such sessions. For example our [Community Spaces](https://wiki.mozilla.org/Participation/Community_Spaces) have, so you can reach out the them to ask for some guidance.
 
 ## Event Flow
 
 * Install Rust
     * [rustup](https://www.rustup.rs) - recommended
     * [Rust downloads](https://www.rust-lang.org/en-US/other-installers.html) (alternative)
-* Read the [Rust book](https://doc.rust-lang.org/stable/book/)
-* Complete the [Rustlings](https://github.com/carols10cents/rustlings) (a great beginners course!)
-* Some projects with great first bugs:
-    * The Rust language and compiler
-        * [Labeled easy](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy)
-        * [Labeled mentor](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-mentor)
-    * [clippy - the popular Rust static analysis tool](https://github.com/Manishearth/rust-clippy)
-    * [Cargo - Rust’s package manager](https://github.com/rust-lang/cargo/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy)
-    * [rustfmt - the Rust source code formatting tool](https://github.com/rust-lang-nursery/rustfmt/issues)
-        * Though some are without clear instructions, the domain is easy to understand (it's mostly manipulating strings), and potentially engaging.
-    * [rustup - the Rust installer](https://github.com/rust-lang-nursery/rustup.rs/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
-    * Rust documentation
-        * [Labeled easy](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs+label%3AE-easy)
-        * [Standard library API docs](https://github.com/rust-lang/rust/issues/29329)
-    * [This Week in Rust](https://this-week-in-rust.org/) also publishes a call for participation each week with hot contribution ideas.
+- Get started!
+    * Read the [Rust book](https://doc.rust-lang.org/stable/book/)
+    * Check [Rust by Example](https://rustbyexample.com/)
+    * Complete some [Rustlings](https://github.com/carols10cents/rustlings) (a great beginners course!)
+    * Try to form some groups to find things they'd like to program.
 
 ## Directly at the end of the activity
 Immediately after the event don’t forget to share the link to the impact form with your attendees:
@@ -109,7 +97,7 @@ Additional to the recommended event flow here are some things we’d like you, t
     * [Here is the Discourse post to write to](https://discourse.mozilla-community.org/t/activate-mozilla-dive-into-rust/10073/1)
 
 ## Extra
-While the focus of this activity should be on these events, there are other ways to stay more involved with the Rust community after.
+While the focus of this activity should be on these events, people can get more involved more involved with the Rust community after.
 
 * Follow up with attendees to highlight [more things happening in the community to get involved with](https://www.rust-lang.org/en-US/community.html)
 </div>

--- a/_pages/rust-hack.md
+++ b/_pages/rust-hack.md
@@ -66,7 +66,7 @@ Some Mozillians have already done such sessions. For example see [past Mozilla R
 
 1. Read the [event guide](/eventguide/) on how to set up an event page and how to organize an event.
 1. Choose a date and secure a venue.
-1. Fill the [event template](https://github.com/rust-community/events-team/issues/new?template=new_meetup.md&labels=meetup,mozilla-activities) for access to the calendar so that you can enter it there.  It will then be sent around with Rust's weekly newsletter and promoted in other fashions. You can also ask the [Rust Community Team](mailto:community@rust-lang.org?subject=[SWAG]) if they can send some stickers.
+1. Fill the [event template](https://github.com/rust-community/events-team/issues/new?template=new_meetup.md&labels=meetup,mozilla-activate) for access to the calendar so that you can enter it there.  It will then be sent around with Rust's weekly newsletter and promoted in other fashions. You can also ask the [Rust Community Team](mailto:community@rust-lang.org?subject=[SWAG]) if they can send some stickers.
 1. Setup the event on the Reps Portal ([instructions](https://wiki.mozilla.org/ReMo/SOPs/Event_hosting)). Please make sure the initiative is set to "MozActivate" and the functional area indicates "Rust".
 
 **1 Week Before the Event**


### PR DESCRIPTION
This changes the Rust activity to an instruction to set up a meetup.

It's still WIP, especially around which links to give to the organisers.