### PR TITLE
Improve footer links (fixes #329, fixes #330)

### DIFF
--- a/public/locales/en-US/activate.ftl
+++ b/public/locales/en-US/activate.ftl
@@ -21,6 +21,7 @@ discussion = Discussion
 contribute = Contribute
 legal = Legal
 
+footer-contribute-title = Contribute
 footer-nav-title = Navigate
 footer-newsletter-title = Newsletter Sign-up
 footer-contibution-2019 = Portions of this content are ©1998–2019 by individual mozilla.org contributors. Content available under a <mozillaLink>Creative Commons license</mozillaLink>.
@@ -29,6 +30,8 @@ footer-cookies = Cookies
 footer-legal = Legal
 footer-github = GitHub (Issue Tracker)
 footer-pontoon = Localize this website
+footer-mozilla-code-base = Mozilla Code Base
+footer-contribute-wiki = Contribute Wiki
 
 not-found-title = 404 - Page not found!
 not-found-description = The page you are looking for could not be found. It may have been removed in the meantime or the URL might be wrong.

--- a/public/locales/en-US/activate.ftl
+++ b/public/locales/en-US/activate.ftl
@@ -28,6 +28,7 @@ footer-privacy-note = Website Privacy Notice
 footer-cookies = Cookies
 footer-legal = Legal
 footer-github = GitHub (Issue Tracker)
+footer-pontoon = Localize this website
 
 not-found-title = 404 - Page not found!
 not-found-description = The page you are looking for could not be found. It may have been removed in the meantime or the URL might be wrong.

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -77,6 +77,8 @@ footer {
 }
 
 .footer__terms {
+  display: flex;
+  justify-content: center;
   margin: 0;
   padding: 0;
   list-style: none;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -46,6 +46,11 @@ class Footer extends Component {
                   </Localized>
                 </NavItem>
               </LinkContainer>
+              <li role="presentation" className="page-link">
+                <a href={`https://github.com/mozilla/activate.mozilla.community/issues`}>
+                  <Localized id="footer-github"><span></span></Localized>
+                </a>
+              </li>
             </Nav>
           </Col>
           <Col lg={4} md={5} sm={6} xs={12}>
@@ -69,11 +74,6 @@ class Footer extends Component {
                 <li>
                   <a href={`https://www.mozilla.org/about/legal/`}>
                     <Localized id="footer-legal"><span></span></Localized>
-                  </a>
-                </li>
-                <li>
-                  <a href={`https://github.com/mozilla/activate.mozilla.community/issues`}>
-                    <Localized id="footer-github"><span></span></Localized>
                   </a>
                 </li>
               </ul>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -16,11 +16,29 @@ class Footer extends Component {
       <footer>
         <Grid>
           <Row>
-          <Col lg={5} md={4} sm={3} xs={6}>
+          <Col lg={4} md={4} sm={4} xs={4}>
             <Link to={`/${currentLocale}`} title="Mozilla Activate">
               <img src="/logo.svg" alt="Mozilla Activate logo" className="footer__logo" />
-            </Link></Col>
-          <Col lg={3} md={3} sm={3} xs={6} className="footer-nav">
+            </Link>
+          </Col>
+          <Col lg={2} md={2} sm={4} xs={4} className="footer-nav">
+            <Localized id="footer-contribute-title">
+              <div className="footer-nav__title"></div>
+            </Localized>
+            <Nav stacked className="footer-nav__menu">
+              <li role="presentation" className="page-link">
+                <a href={`https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Introduction`}>
+                  <Localized id="footer-mozilla-code-base"><span></span></Localized>
+                </a>
+              </li>
+              <li role="presentation" className="page-link">
+                <a href={`https://wiki.mozilla.org/Contribute`}>
+                  <Localized id="footer-contribute-wiki"><span></span></Localized>
+                </a>
+              </li>
+            </Nav>
+          </Col>
+          <Col lg={2} md={2} sm={4} xs={4} className="footer-nav">
             <Localized id="footer-nav-title">
               <div className="footer-nav__title"></div>
             </Localized>
@@ -58,7 +76,7 @@ class Footer extends Component {
               </li>
             </Nav>
           </Col>
-          <Col lg={4} md={5} sm={6} xs={12}>
+          <Col lg={4} md={4} sm={12} xs={12}>
             <NewsletterFooterForm/>
           </Col>
           </Row>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -51,6 +51,11 @@ class Footer extends Component {
                   <Localized id="footer-github"><span></span></Localized>
                 </a>
               </li>
+              <li role="presentation" className="page-link">
+                <a href={`https://pontoon.mozilla.org/projects/mozilla-activate/`}>
+                  <Localized id="footer-pontoon"><span></span></Localized>
+                </a>
+              </li>
             </Nav>
           </Col>
           <Col lg={4} md={5} sm={6} xs={12}>


### PR DESCRIPTION
You can find this to test here: http://activate-test.michaelkohler.info/. You might need to hard reload to see the changes.

* Moved the GitHub link to the "Navigate" section
* Added the Pontoon link to the "Navigate" section (issue #329)
* Added "Contribute" section (issue #330)
* Moved the "Website Terms" links all the way at the bottom to be center-aligned

<img width="595" alt="Screenshot 2019-03-23 at 15 16 09" src="https://user-images.githubusercontent.com/330324/54867291-f4376580-4d7e-11e9-8fb2-e8f93917a140.png">
<img width="973" alt="Screenshot 2019-03-23 at 15 16 14" src="https://user-images.githubusercontent.com/330324/54867292-f4376580-4d7e-11e9-8da9-f060a65c8399.png">
<img width="1268" alt="Screenshot 2019-03-23 at 15 16 19" src="https://user-images.githubusercontent.com/330324/54867293-f4376580-4d7e-11e9-95cf-eddd294599a8.png">
<img width="1631" alt="Screenshot 2019-03-23 at 15 16 26" src="https://user-images.githubusercontent.com/330324/54867294-f4376580-4d7e-11e9-9d43-ccee16c3b494.png">
<img width="1680" alt="Screenshot 2019-03-23 at 15 16 35" src="https://user-images.githubusercontent.com/330324/54867295-f4cffc00-4d7e-11e9-8353-df34227dc7fd.png">
